### PR TITLE
Remove null usages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-process-reporter",
-  "version": "1.2.1",
+  "version": "1.3.1",
   "scripts": {
     "test": "mocha --opts tests/mocha.opts tests/**/*-test.{ts,tsx} && npm run lint && npm run build",
     "lint": "eslint 'src/**/*.{ts,tsx}' 'tests/**/*.{ts,tsx}'",

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ const getAppUsage = (pid: number): Promise<PidUsage[]> => {
   return getPpid(pid)
     .then(pidtree)
     .then(pidusage)
-    .then((usages: any) => Object.values(usages) as PidUsage[]);
+    .then((usages: any) => Object.values(usages).filter(Boolean) as PidUsage[]);
 };
 
 let getSharedProcessMetricsPollerByPid = (pid: number, samplingInterval: number) =>


### PR DESCRIPTION
With `pidusage` some usages appear as null (process that might have been closed for instance). This just ensure we filter them to avoid errors.